### PR TITLE
Some display picks from 5.15

### DIFF
--- a/techpack/display/msm/dp/dp_hdcp2p2.c
+++ b/techpack/display/msm/dp/dp_hdcp2p2.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
+ * Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
  * Copyright (c) 2016-2021, The Linux Foundation. All rights reserved.
  */
 
@@ -871,7 +872,7 @@ static int dp_hdcp2p2_main(void *data)
 	enum hdcp_transport_wakeup_cmd cmd;
 
 	while (1) {
-		wait_event(ctrl->wait_q,
+		wait_event_idle(ctrl->wait_q,
 			!kfifo_is_empty(&ctrl->cmd_q) ||
 			kthread_should_stop() ||
 			kthread_should_park());

--- a/techpack/display/msm/sde/sde_encoder.c
+++ b/techpack/display/msm/sde/sde_encoder.c
@@ -3210,6 +3210,31 @@ void sde_encoder_virt_reset(struct drm_encoder *drm_enc)
 	sde_rm_release(&sde_kms->rm, drm_enc, false);
 }
 
+static void sde_encoder_wait_for_vsync_event_complete(struct sde_encoder_virt *sde_enc)
+{
+	u32 timeout_ms = DEFAULT_KICKOFF_TIMEOUT_MS;
+	int i, ret;
+
+	if (sde_enc->cur_master)
+		timeout_ms = sde_enc->cur_master->kickoff_timeout_ms;
+
+	ret = wait_event_timeout(sde_enc->vsync_event_wq,
+			!sde_enc->vblank_enabled,
+			msecs_to_jiffies(timeout_ms));
+	SDE_EVT32(timeout_ms, ret);
+
+	if (!ret) {
+		SDE_ERROR("vsync event complete timed out %d\n", ret);
+		SDE_EVT32(ret, SDE_EVTLOG_ERROR);
+		for (i = 0; i < sde_enc->num_phys_encs; i++) {
+			struct sde_encoder_phys *phys = sde_enc->phys_encs[i];
+
+			if (phys && phys->ops.control_vblank_irq)
+				phys->ops.control_vblank_irq(phys, false);
+		}
+	}
+}
+
 static void sde_encoder_virt_disable(struct drm_encoder *drm_enc)
 {
 	struct sde_encoder_virt *sde_enc = NULL;
@@ -3295,6 +3320,13 @@ static void sde_encoder_virt_disable(struct drm_encoder *drm_enc)
 		sde_encoder_resource_control(drm_enc,
 				SDE_ENC_RC_EVENT_PRE_STOP);
 	}
+
+	/*
+	 * wait for any pending vsync timestamp event to sf
+	 * to ensure vbalnk irq is disabled.
+	 */
+	if (sde_enc->vblank_enabled)
+		sde_encoder_wait_for_vsync_event_complete(sde_enc);
 
 	/*
 	 * disable dce after the transfer is complete (for command mode)
@@ -3593,6 +3625,9 @@ void sde_encoder_register_vblank_callback(struct drm_encoder *drm_enc,
 			phys->ops.control_vblank_irq(phys, enable);
 	}
 	sde_enc->vblank_enabled = enable;
+
+	if (!enable)
+		wake_up_all(&sde_enc->vsync_event_wq);
 }
 
 void sde_encoder_register_frame_event_callback(struct drm_encoder *drm_enc,
@@ -5697,6 +5732,7 @@ struct drm_encoder *sde_encoder_init(struct drm_device *dev, struct msm_display_
 	}
 
 	mutex_init(&sde_enc->rc_lock);
+	init_waitqueue_head(&sde_enc->vsync_event_wq);
 	kthread_init_delayed_work(&sde_enc->delayed_off_work,
 			sde_encoder_off_work);
 	sde_enc->vblank_enabled = false;

--- a/techpack/display/msm/sde/sde_encoder.h
+++ b/techpack/display/msm/sde/sde_encoder.h
@@ -193,6 +193,7 @@ enum sde_enc_rc_states {
  *				encoder due to autorefresh concurrency.
  * @fps_switch_high_to_low:	boolean to note direction of fps switch
  * @update_clocks_on_complete_commit:	boolean to force update clocks
+ * @vsync_event_wq              Queue to wait for the vsync event complete
  */
 struct sde_encoder_virt {
 	struct drm_encoder base;
@@ -264,6 +265,7 @@ struct sde_encoder_virt {
 	bool update_clocks_on_complete_commit;
 	bool prepare_kickoff;
 	bool ready_kickoff;
+	wait_queue_head_t vsync_event_wq;
 };
 
 #define to_sde_encoder_virt(x) container_of(x, struct sde_encoder_virt, base)

--- a/techpack/display/msm/sde_hdcp_2x.c
+++ b/techpack/display/msm/sde_hdcp_2x.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
+ * Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
  * Copyright (c) 2015-2021, The Linux Foundation. All rights reserved.
  */
 
@@ -970,7 +971,7 @@ static int sde_hdcp_2x_main(void *data)
 	enum sde_hdcp_2x_wakeup_cmd cmd;
 
 	while (1) {
-		wait_event(hdcp->wait_q,
+		wait_event_idle(hdcp->wait_q,
 			!kfifo_is_empty(&hdcp->cmd_q) ||
 			kthread_should_stop() ||
 			kthread_should_park());


### PR DESCRIPTION
Perhaps there are more, but picked the useful ones that I found in a quick look.
Also may I suggest shipping source-built msm_drm in HyperOS modules, since everything works fine.