### PR TITLE
Melt build fix

### DIFF
--- a/drivers/clk/qcom/trace.h
+++ b/drivers/clk/qcom/trace.h
@@ -79,7 +79,7 @@ DEFINE_EVENT(clk_measure_support, clk_measure,
 /* This part must be outside protection */
 
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/clk/qcom
 
 #undef TRACE_INCLUDE_FILE
 #define TRACE_INCLUDE_FILE trace

--- a/drivers/cpuidle/governors/trace-cluster-lpm.h
+++ b/drivers/cpuidle/governors/trace-cluster-lpm.h
@@ -111,7 +111,7 @@ TRACE_EVENT(cluster_enter,
 #endif /* _TRACE_QCOM_LPM_H */
 
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/cpuidle/governors
 
 #undef TRACE_INCLUDE_FILE
 #define TRACE_INCLUDE_FILE trace-cluster-lpm

--- a/drivers/cpuidle/governors/trace-qcom-lpm.h
+++ b/drivers/cpuidle/governors/trace-qcom-lpm.h
@@ -81,7 +81,7 @@ TRACE_EVENT(gov_pred_hist,
 #endif /* _TRACE_QCOM_LPM_H */
 
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/cpuidle/governors
 
 #undef TRACE_INCLUDE_FILE
 #define TRACE_INCLUDE_FILE trace-qcom-lpm

--- a/drivers/i2c/busses/i2c-qup-trace.h
+++ b/drivers/i2c/busses/i2c-qup-trace.h
@@ -39,7 +39,7 @@ TRACE_EVENT(i2c_log_info,
 
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/i2c/busses
 #define TRACE_INCLUDE_FILE i2c-qup-trace
 #include <trace/define_trace.h>
 

--- a/drivers/platform/msm/qup-common-trace.h
+++ b/drivers/platform/msm/qup-common-trace.h
@@ -39,7 +39,7 @@ TRACE_EVENT(geni_log_info,
 
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/platform/msm
 #define TRACE_INCLUDE_FILE qup-common-trace
 #include <trace/define_trace.h>
 

--- a/drivers/slimbus/trace.h
+++ b/drivers/slimbus/trace.h
@@ -38,7 +38,7 @@ TRACE_EVENT(slimbus_dbg,
 /* this part has to be here */
 
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/slimbus
 
 #undef TRACE_INCLUDE_FILE
 #define TRACE_INCLUDE_FILE trace

--- a/drivers/soc/qcom/dcvs/trace-dcvs.h
+++ b/drivers/soc/qcom/dcvs/trace-dcvs.h
@@ -344,7 +344,7 @@ TRACE_EVENT(bwprof_last_sample,
 #endif /* _TRACE_DCVS_H */
 
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/soc/qcom/dcvs
 
 #undef TRACE_INCLUDE_FILE
 #define TRACE_INCLUDE_FILE trace-dcvs

--- a/drivers/soc/qcom/hyp_core_ctl_trace.h
+++ b/drivers/soc/qcom/hyp_core_ctl_trace.h
@@ -6,7 +6,7 @@
 #undef TRACE_SYSTEM
 #define TRACE_SYSTEM hyp_core_ctl
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/soc/qcom
 #undef TRACE_INCLUDE_FILE
 #define TRACE_INCLUDE_FILE hyp_core_ctl_trace
 

--- a/drivers/spi/spi-qup-trace.h
+++ b/drivers/spi/spi-qup-trace.h
@@ -39,7 +39,7 @@ TRACE_EVENT(spi_log_info,
 
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/spi
 #define TRACE_INCLUDE_FILE spi-qup-trace
 #include <trace/define_trace.h>
 

--- a/drivers/staging/binder_prio/binder_prio.c
+++ b/drivers/staging/binder_prio/binder_prio.c
@@ -4,8 +4,8 @@
 #include <uapi/linux/android/binder.h>
 #include <uapi/linux/sched/types.h>
 #include <linux/sched/prio.h>
-#include <../../android/binder_internal.h>
-#include <../../../kernel/sched/sched.h>
+#include "../../android/binder_internal.h"
+#include "../../../kernel/sched/sched.h"
 #include <linux/string.h>
 
 static const char *task_name[] = {

--- a/drivers/tty/serial/serial_trace.h
+++ b/drivers/tty/serial/serial_trace.h
@@ -34,6 +34,6 @@ TRACE_EVENT(serial_info,
 
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/tty/serial
 #define TRACE_INCLUDE_FILE serial_trace
 #include <trace/define_trace.h>

--- a/scripts/link-vmlinux.sh
+++ b/scripts/link-vmlinux.sh
@@ -48,7 +48,7 @@ gen_initcalls()
 {
 	info GEN .tmp_initcalls.lds
 
-	${PYTHON} ${srctree}/scripts/jobserver-exec		\
+	${PYTHON3} ${srctree}/scripts/jobserver-exec		\
 	${PERL} ${srctree}/scripts/generate_initcall_order.pl	\
 		${KBUILD_VMLINUX_OBJS} ${KBUILD_VMLINUX_LIBS}	\
 		> .tmp_initcalls.lds


### PR DESCRIPTION
1.for some reason the compiler can't recognize some of the defines, just add a relative path to fix it.
2.there's commonly a version follows "python" in some environment like ubuntu 22.04, use $PYTHON3 in the predefines to make it a exactly version of python to build.