### PR TITLE
unicode: treat empty decomposition as CCC STOPPER to prevent bypass

### DIFF
--- a/fs/unicode/utf8-norm.c
+++ b/fs/unicode/utf8-norm.c
@@ -689,26 +689,23 @@ int utf8byte(struct utf8cursor *u8c)
 			return -1;
 
 		ccc = LEAF_CCC(leaf);
-		/* Characters that are too new have CCC 0. */
-		if (utf8agetab[LEAF_GEN(leaf)] > u8c->data->maxage) {
-			ccc = STOPPER;
-		} else if (ccc == DECOMPOSE) {
-			u8c->len -= utf8clen(u8c->s);
-			u8c->p = u8c->s + utf8clen(u8c->s);
-			u8c->s = LEAF_STR(leaf);
-			/* Empty decomposition implies CCC 0. */
-			if (*u8c->s == '\0') {
-				if (u8c->ccc == STOPPER)
-					continue;
-				ccc = STOPPER;
-				goto ccc_mismatch;
-			}
-
-			leaf = utf8lookup(u8c->data, u8c->hangul, u8c->s);
-			if (!leaf)
-				return -1;
-			ccc = LEAF_CCC(leaf);
-		}
+    		/* Characters that are too new have CCC 0. */
+    		if (utf8agetab[LEAF_GEN(leaf)] > u8c->data->maxage) {
+      			ccc = STOPPER;
+    		} else if (ccc == DECOMPOSE) {
+      			if (*LEAF_STR(leaf) == '\0') { // 先判空
+        			ccc = STOPPER; // 只设STOPPER，不推进
+      			} else {
+        			// 非空才推进
+        			u8c->len -= utf8clen(u8c->s);
+        			u8c->p = u8c->s + utf8clen(u8c->s);
+        			u8c->s = LEAF_STR(leaf);
+        			// 然后再lookup
+        			leaf = utf8lookup(u8c->data, u8c->hangul, u8c->s);
+        			if (!leaf) return -1;
+        			ccc = LEAF_CCC(leaf);
+      			}
+    		}
 
 		/*
 		 * If this is not a stopper, then see if it updates


### PR DESCRIPTION
Zero-width space (U+200B and similar) have empty decomposition in NFC/NFD.
Previously they were treated as CCC=0, allowing them to bypass composition
checks and potentially defeat security restrictions that rely on normalized
UTF-8 comparison.

Treat empty decomposition as a combining class stopper and only advance the
cursor when the decomposition is non-empty.

Link: https://t.me/xiaotong_channel/72
Signed-off-by: ~J3mbo4D~ <creamylofly@gmail.com>
Signed-off-by: bachnxuan <bachnxuan@gmail.com>
Signed-off-by: Guxin12 <2452148391@qq.com>